### PR TITLE
Preserve devcontainer connection during firewall init

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -74,16 +74,16 @@ echo "Host network detected as: $HOST_NETWORK"
 iptables -A INPUT -s "$HOST_NETWORK" -j ACCEPT
 iptables -A OUTPUT -d "$HOST_NETWORK" -j ACCEPT
 
-# Set default policies to DROP first
+# Allow established connections for already approved traffic before tightening defaults
+iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+# Now set default policies to DROP
 iptables -P INPUT DROP
 iptables -P FORWARD DROP
 iptables -P OUTPUT DROP
 
-# First allow established connections for already approved traffic
-iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
-iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
-
-# Then allow only specific outbound traffic to allowed domains
+# Allow only specific outbound traffic to allowed domains
 iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
 
 echo "Firewall configuration complete"


### PR DESCRIPTION
## Summary
- Ensure firewall initialization retains the devcontainer shell by accepting established connections before switching default policies to DROP

## Testing
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository InRelease not signed)*
- `bash .devcontainer/init-firewall.sh >/tmp/firewall.log && tail -n 20 /tmp/firewall.log` *(fails: iptables-save: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a06b2574bc8322973463699b458c15