### PR TITLE
Wait for firewall init before container attach

### DIFF
--- a/.devcontainer/claude.bat
+++ b/.devcontainer/claude.bat
@@ -5,10 +5,10 @@ echo ================================================
 
 REM Step 0: Generate a deterministic container name based on this directory
 for /f %%i in ('powershell -NoProfile -Command "$p=(Resolve-Path ""%~dp0"").Path;$h=[System.Security.Cryptography.MD5]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes($p));$hex=[System.BitConverter]::ToString($h).Replace('-','').ToLower();$hex.Substring(0,12)"') do set "CLAUDE_CONTAINER_NAME=claude-code-dev-%%i"
-echo [0/3] Preparing container %CLAUDE_CONTAINER_NAME%...
+echo [0/4] Preparing container %CLAUDE_CONTAINER_NAME%...
 
 REM Step 1: Build the Docker image
-echo [1/3] Building Docker image...
+echo [1/4] Building Docker image...
 docker-compose build
 
 if %errorlevel% neq 0 (
@@ -23,7 +23,7 @@ if not exist ".claude.json" (
 )
 
 REM Step 2: Start the container in detached mode
-echo [2/3] Starting container in detached mode...
+echo [2/4] Starting container in detached mode...
 docker-compose up -d
 
 if %errorlevel% neq 0 (
@@ -32,9 +32,18 @@ if %errorlevel% neq 0 (
     exit /b 1
 )
 
-REM Step 3: Enter the container
+REM Step 3: Wait for firewall initialization
+echo [3/4] Waiting for firewall to initialize...
+:wait_firewall
+docker exec %CLAUDE_CONTAINER_NAME% bash -c "test -f /tmp/firewall.ready" >nul 2>&1
+if %errorlevel% neq 0 (
+    timeout /t 1 >nul
+    goto wait_firewall
+)
+
+REM Step 4: Enter the container
 echo.
-echo [3/3] Setup complete! Entering container...
+echo [4/4] Setup complete! Entering container...
 echo.
 echo IMPORTANT: Run 'claude-code auth' to set up your API key
 echo Your repository root is available at /workspace

--- a/.devcontainer/claude.sh
+++ b/.devcontainer/claude.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Generate deterministic container name based on project path
+CONTAINER_HASH="$(printf "%s" "$ROOT_DIR" | md5sum | head -c12)"
+CLAUDE_CONTAINER_NAME="claude-code-dev-$CONTAINER_HASH"
+
+echo "==============================================="
+echo "Setting up Claude Code Docker environment..."
+echo "==============================================="
+echo "[0/4] Preparing container $CLAUDE_CONTAINER_NAME..."
+
+# Step 1: Build the Docker image
+echo "[1/4] Building Docker image..."
+docker-compose -f "$SCRIPT_DIR/docker-compose.yml" build
+
+# Ensure .claude.json exists
+if [ ! -f "$ROOT_DIR/.claude.json" ]; then
+  echo '{}' > "$ROOT_DIR/.claude.json"
+fi
+
+# Step 2: Start the container in detached mode
+echo "[2/4] Starting container in detached mode..."
+CLAUDE_CONTAINER_NAME="$CLAUDE_CONTAINER_NAME" docker-compose -f "$SCRIPT_DIR/docker-compose.yml" up -d
+
+# Step 3: Wait for firewall initialization
+echo "[3/4] Waiting for firewall to initialize..."
+until docker exec "$CLAUDE_CONTAINER_NAME" bash -c "test -f /tmp/firewall.ready" >/dev/null 2>&1; do
+  sleep 1
+done
+
+# Step 4: Enter the container
+cat <<MSG
+[4/4] Setup complete! Entering container...
+
+IMPORTANT: Run 'claude-code auth' to set up your API key
+Your repository root is available at /workspace
+
+===============================================
+Quick commands inside the container:
+  claude-code auth          - Set up API key
+  claude-code --help        - Show help
+  cd /workspace            - Go to repository root
+  exit                     - Leave container
+===============================================
+MSG
+
+docker exec -it "$CLAUDE_CONTAINER_NAME" bash
+
+echo
+cat <<MSG
+===============================================
+You've exited the Claude Code container.
+The container is still running in the background.
+
+To re-enter: docker exec -it $CLAUDE_CONTAINER_NAME bash
+To stop: docker stop $CLAUDE_CONTAINER_NAME
+===============================================
+MSG

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -102,3 +102,6 @@ if ! curl --connect-timeout 5 https://api.anthropic.com >/dev/null 2>&1; then
 else
     echo "Firewall verification passed - able to reach https://api.anthropic.com as expected"
 fi
+
+# Signal that firewall setup is complete
+touch /tmp/firewall.ready


### PR DESCRIPTION
## Summary
- signal firewall completion in init-firewall.sh
- wait for readiness marker before attaching in claude.bat
- add claude.sh to launch container from Unix shells

## Testing
- `bash -n .devcontainer/init-firewall.sh`
- `bash -n .devcontainer/claude.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a07d9368ec8322b4c2bb259ec56a0e