### PR TITLE
Run setup validation on shell start

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -79,4 +79,7 @@ RUN chmod +x /usr/local/bin/init-firewall.sh && \
 RUN passwd -l root
 
 COPY validate-setup.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/validate-setup.sh \
+ && printf '\nif [ -z "${VALIDATE_SETUP_DONE:-}" ] && [ -x /usr/local/bin/validate-setup.sh ]; then\n  /usr/local/bin/validate-setup.sh || true\n  export VALIDATE_SETUP_DONE=1\nfi\n' >> /root/.bashrc \
+ && printf '\nif [ -z "${VALIDATE_SETUP_DONE:-}" ] && [ -x /usr/local/bin/validate-setup.sh ]; then\n  /usr/local/bin/validate-setup.sh || true\n  export VALIDATE_SETUP_DONE=1\nfi\n' >> /home/node/.bashrc
 USER node


### PR DESCRIPTION
## Summary
- Ensure validate-setup.sh executes automatically when any Bash shell is launched inside the container
- Append guard to root and node .bashrc to run validation only once per session

## Testing
- `bash .devcontainer/validate-setup.sh` *(fails: su still works)*

------
https://chatgpt.com/codex/tasks/task_e_68a090bb43e88322af5fa2374b4e2785